### PR TITLE
Use of a non runtime-blocking sleep/usleep implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm i adafruit-i2c-pwm-driver
 
 ```js
 const makePwmDriver = require('adafruit-i2c-pwm')
-const pwmDriver = makePwmDriver(0x40, '/dev/i2c-1')
+const pwmDriver = makePwmDriver({address: 0x40, device: '/dev/i2c-1'})
 
 pwmDriver.setPWMFreq(50)
 pwmDriver.setPWM(2) // channel, on , off
@@ -38,7 +38,7 @@ you can find a simple example [here](https://raw.githubusercontent.com/kaosat-de
 ## API
 
 
-`makePwmDriver(address:Number,device:String,debug:Bool)`
+`makePwmDriver({address:Number,device:String,debug:Bool})`
 
 Setting up a new PwmDriver
 

--- a/dist/i2cWrapper.js
+++ b/dist/i2cWrapper.js
@@ -2,6 +2,9 @@
 
 var I2C = require('i2c');
 
+/*
+  this wrappers wraps the i2c readBytes, writeBytes functions and returns promises
+*/
 function makeI2CWrapper(address, _ref) {
   var device = _ref.device,
       debug = _ref.debug;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var _sleep = require('./sleep');
+
 var I2C = require('./i2cWrapper');
-var sleep = require('sleep');
+
 
 // ============================================================================
 // Adafruit PCA9685 16-Channel PWM Servo Driver
@@ -52,7 +54,7 @@ function makePwmDriver(options) {
       console.log('Reseting PCA9685, mode1: ' + MODE1);
     }
     // i2c.writeByte(0x06) // SWRST
-    //i2c.writeBytes(MODE1, 0x00)
+    // i2c.writeBytes(MODE1, 0x00)
     //
     /*await setAllPWM(0, 0)
     await i2c.writeBytes(MODE2, OUTDRV)
@@ -72,15 +74,16 @@ function makePwmDriver(options) {
     setAllPWM(0, 0);
     i2c.writeBytes(MODE2, OUTDRV);
     i2c.writeBytes(MODE1, ALLCALL);
-    sleep.usleep(5000);
-    i2c.readBytes(MODE1, 1).then(function (mode1) {
-      mode1 = mode1 & ~SLEEP; // wake up (reset sleep)
-      return i2c.writeBytes(MODE1, mode1);
-    }).then(sleep.usleep(5000)) // wait for oscillator)
-    .then(function (x) {
-      return debug ? console.log('init done ') : '';
-    }).catch(function (e) {
-      return console.error('error in init', e);
+    (0, _sleep.usleep)(5000).then(function (x) {
+      return i2c.readBytes(MODE1, 1).then(function (mode1) {
+        mode1 = mode1 & ~SLEEP; // wake up (reset sleep)
+        return i2c.writeBytes(MODE1, mode1);
+      }).then((0, _sleep.usleep)(5000)) // wait for oscillator)
+      .then(function (x) {
+        return debug ? console.log('init done ') : '';
+      }).catch(function (e) {
+        return console.error('error in init', e);
+      });
     });
   };
 
@@ -109,8 +112,9 @@ function makePwmDriver(options) {
       i2c.writeBytes(MODE1, newmode); // go to sleep
       i2c.writeBytes(PRESCALE, Math.floor(prescale));
       i2c.writeBytes(MODE1, oldmode);
-      sleep.usleep(5000);
-      i2c.writeBytes(MODE1, oldmode | 0x80);
+      (0, _sleep.usleep)(5000).then(function (x) {
+        return i2c.writeBytes(MODE1, oldmode | 0x80);
+      });
     });
   };
 
@@ -151,6 +155,5 @@ function makePwmDriver(options) {
     setPWM: setPWM,
     setAllPWM: setAllPWM,
     setPWMFreq: setPWMFreq,
-    stop: stop
-  };
+    stop: stop };
 }

--- a/dist/sleep.js
+++ b/dist/sleep.js
@@ -12,7 +12,7 @@ function sleep(seconds) {
     var timer = new NanoTimer();
     timer.setTimeout(function (x) {
       return resolve(seconds);
-    }, '', seconds + 'u');
+    }, '', seconds + 's');
     timer.clearInterval();
   });
 }

--- a/dist/sleep.js
+++ b/dist/sleep.js
@@ -1,0 +1,28 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.sleep = sleep;
+exports.usleep = usleep;
+var NanoTimer = require('nanotimer');
+
+function sleep(seconds) {
+  return new Promise(function (resolve, reject) {
+    var timer = new NanoTimer();
+    timer.setTimeout(function (x) {
+      return resolve(seconds);
+    }, '', seconds + 'u');
+    timer.clearInterval();
+  });
+}
+
+function usleep(micros) {
+  return new Promise(function (resolve, reject) {
+    var timer = new NanoTimer();
+    timer.setTimeout(function (x) {
+      return resolve(micros);
+    }, '', micros + 'u');
+    timer.clearInterval();
+  });
+}

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,6 @@
 const makePwmDriver = require('../dist/index')
-// const makePwmDriver = require('adafruit-i2c-pwm')
-const sleep = require('sleep').sleep
+// const makePwmDriver = require('adafruit-i2c-pwm')// use this one in real use case
+const sleep = require('../dist/sleep').sleep
 
 const pwm = makePwmDriver(0x40, '/dev/i2c-1')
 
@@ -14,11 +14,11 @@ setTimeout(function () {
   console.log('Moving servo on channel 0, press Ctrl-C to quit...')
   while(true) {
     // Move servo on channel O between extremes.
-    pwm.setPWM(0, 0, servo_min)
-    //pwm.setPWM(12, 0, servo_min)
     sleep(1)
-    pwm.setPWM(0, 0, servo_max)
-    //pwm.setPWM(12, 0, servo_max)
-    sleep(1)
+      .then(x => pwm.setPWM(0, 0, servo_min))
+      .then(x => sleep(1))
+      .then(x => pwm.setPWM(0, 0, servo_max))
+  // pwm.setPWM(12, 0, servo_min)
+  // pwm.setPWM(12, 0, servo_max)
   }
 }, 5000)

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -2,7 +2,7 @@ const makePwmDriver = require('../dist/index')
 // const makePwmDriver = require('adafruit-i2c-pwm')// use this one in real use case
 const sleep = require('../dist/sleep').sleep
 
-const pwm = makePwmDriver(0x40, '/dev/i2c-1')
+const pwm = makePwmDriver({address: 0x40, device: '/dev/i2c-1', debug: false})
 
 // Configure min and max servo pulse lengths
 const servo_min = 150 // Min pulse length out of 4096
@@ -10,15 +10,13 @@ const servo_max = 600 // Max pulse length out of 4096
 
 pwm.setPWMFreq(50)
 
-setTimeout(function () {
-  console.log('Moving servo on channel 0, press Ctrl-C to quit...')
-  while(true) {
-    // Move servo on channel O between extremes.
-    sleep(1)
-      .then(x => pwm.setPWM(0, 0, servo_min))
-      .then(x => sleep(1))
-      .then(x => pwm.setPWM(0, 0, servo_max))
-  // pwm.setPWM(12, 0, servo_min)
-  // pwm.setPWM(12, 0, servo_max)
-  }
-}, 5000)
+const loop = function () {
+  return sleep(1)
+    .then(function () { return pwm.setPWM(0, 0, servo_min) })
+    .then(function () { return sleep(1) })
+    .then(function () { return pwm.setPWM(0, 0, servo_max) })
+    .then(loop)
+}
+
+sleep(5)
+  .then(loop)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adafruit-i2c-pwm-driver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "node.js /i2c control for the Adafruit PWM servo driver",
   "main": "dist/index.js",
   "author": "Mark Moissette",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "i2c": "0.2.3",
-    "nanotimer": "^0.3.14",
-    "sleep": "4.0.0"
+    "nanotimer": "^0.3.14"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "i2c": "0.2.3",
+    "nanotimer": "^0.3.14",
     "sleep": "4.0.0"
   },
   "devDependencies": {

--- a/src/i2cWrapper.js
+++ b/src/i2cWrapper.js
@@ -1,5 +1,8 @@
 const I2C = require('i2c')
 
+/*
+  this wrappers wraps the i2c readBytes, writeBytes functions and returns promises
+*/
 function makeI2CWrapper (address, {device, debug}) {
   const i2c = new I2C(address, {device})
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const I2C = require('./i2cWrapper')
-const sleep = require('sleep')
+import { sleep, usleep } from './sleep'
 
 // ============================================================================
 // Adafruit PCA9685 16-Channel PWM Servo Driver
@@ -45,7 +45,7 @@ function makePwmDriver (options) {
       console.log(`Reseting PCA9685, mode1: ${MODE1}`)
     }
     // i2c.writeByte(0x06) // SWRST
-    //i2c.writeBytes(MODE1, 0x00)
+    // i2c.writeBytes(MODE1, 0x00)
     //
     /*await setAllPWM(0, 0)
     await i2c.writeBytes(MODE2, OUTDRV)
@@ -67,15 +67,16 @@ function makePwmDriver (options) {
     setAllPWM(0, 0)
     i2c.writeBytes(MODE2, OUTDRV)
     i2c.writeBytes(MODE1, ALLCALL)
-    sleep.usleep(5000)
-    i2c.readBytes(MODE1, 1)
-      .then((mode1) => {
-        mode1 = mode1 & ~SLEEP // wake up (reset sleep)
-        return i2c.writeBytes(MODE1, mode1)
-      })
-      .then(sleep.usleep(5000)) // wait for oscillator)
-      .then(x => debug? console.log('init done '): '')
-      .catch(e=>console.error('error in init', e))
+    usleep(5000)
+      .then(x => i2c.readBytes(MODE1, 1)
+        .then((mode1) => {
+          mode1 = mode1 & ~SLEEP // wake up (reset sleep)
+          return i2c.writeBytes(MODE1, mode1)
+        })
+        .then(usleep(5000)) // wait for oscillator)
+        .then(x => debug ? console.log('init done ') : '')
+        .catch(e => console.error('error in init', e))
+    )
   }
 
   const setPWMFreq = freq => {
@@ -104,8 +105,8 @@ function makePwmDriver (options) {
         i2c.writeBytes(MODE1, newmode) // go to sleep
         i2c.writeBytes(PRESCALE, Math.floor(prescale))
         i2c.writeBytes(MODE1, oldmode)
-        sleep.usleep(5000)
-        i2c.writeBytes(MODE1, oldmode | 0x80)
+        usleep(5000)
+          .then(x => i2c.writeBytes(MODE1, oldmode | 0x80))
       })
   }
 
@@ -144,6 +145,5 @@ function makePwmDriver (options) {
     setPWM,
     setAllPWM,
     setPWMFreq,
-    stop
-  }
+  stop}
 }

--- a/src/sleep.js
+++ b/src/sleep.js
@@ -1,0 +1,19 @@
+const NanoTimer = require('nanotimer')
+
+export function sleep (seconds) {
+  return new Promise(
+    function (resolve, reject) {
+      const timer = new NanoTimer()
+      timer.setTimeout(x => resolve(seconds), '', `${seconds}u`)
+      timer.clearInterval()
+    })
+}
+
+export function usleep (micros) {
+  return new Promise(
+    function (resolve, reject) {
+      const timer = new NanoTimer()
+      timer.setTimeout(x => resolve(micros), '', `${micros}u`)
+      timer.clearInterval()
+    })
+}

--- a/src/sleep.js
+++ b/src/sleep.js
@@ -4,7 +4,7 @@ export function sleep (seconds) {
   return new Promise(
     function (resolve, reject) {
       const timer = new NanoTimer()
-      timer.setTimeout(x => resolve(seconds), '', `${seconds}u`)
+      timer.setTimeout(x => resolve(seconds), '', `${seconds}s`)
       timer.clearInterval()
     })
 }


### PR DESCRIPTION
This PR attempts to add an alternate sleep/ usleep implementation to prevent the issues steming from using the [node-sleep package in production](https://github.com/erikdubbelboer/node-sleep/issues/60#issuecomment-258719307).

Thanks for the heads-up about the issue @EMCP.
Deployed , tested & validated my test RaspberryPi 
